### PR TITLE
EG-400: Accessibility Statement

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -32,6 +32,10 @@ trait AppConfig {
   val externalGuidanceBaseUrl: String
   val config: Configuration
   val sessionProcessTTLMinutes: Int
+  val cookies: String
+  val privacy: String
+  val termsConditions: String
+  val govukHelp: String
 }
 
 @Singleton
@@ -50,4 +54,9 @@ class AppConfigImpl @Inject() (val config: Configuration, servicesConfig: Servic
   lazy val sessionProcessTTLMinutes: Int = servicesConfig.getInt("mongodb.sessionProcessTTLMinutes")
 
   lazy val externalGuidanceBaseUrl: String = servicesConfig.baseUrl("external-guidance")
+
+  lazy val cookies: String = config.get[String]("urls.footer.cookies")
+  lazy val privacy: String = config.get[String]("urls.footer.privacy")
+  lazy val termsConditions: String = config.get[String]("urls.footer.termsConditions")
+  lazy val govukHelp: String = config.get[String]("urls.footer.govukHelp")
 }

--- a/app/controllers/AccessibilityStatementController.scala
+++ b/app/controllers/AccessibilityStatementController.scala
@@ -23,9 +23,10 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 import scala.concurrent.Future
+
 @Singleton
 class AccessibilityStatementController @Inject() (appConfig: AppConfig, mcc: MessagesControllerComponents, view: views.html.accessibility_statement)
-  extends FrontendController(mcc)
+    extends FrontendController(mcc)
     with I18nSupport {
 
   implicit val config: AppConfig = appConfig

--- a/app/controllers/AccessibilityStatementController.scala
+++ b/app/controllers/AccessibilityStatementController.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import javax.inject.{Inject, Singleton}
+import config.AppConfig
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
+import scala.concurrent.Future
+@Singleton
+class AccessibilityStatementController @Inject() (appConfig: AppConfig, mcc: MessagesControllerComponents, view: views.html.accessibility_statement)
+  extends FrontendController(mcc)
+    with I18nSupport {
+
+  implicit val config: AppConfig = appConfig
+
+  val getPage: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(view()))
+  }
+
+}

--- a/app/views/accessibility_statement.scala.html
+++ b/app/views/accessibility_statement.scala.html
@@ -1,0 +1,108 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+
+@this(layout: main_layout)
+
+@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@layout(messages("accessibility.title")) {
+    <h1 class="govuk-heading-xl">@messages("compliant.one.heading")</h1>
+    <p class="govuk-body-l">@messages("compliant.one.lede")</p>
+
+    <p class="govuk-body">@messages("compliant.one.p1.1")
+        <a href="https://www.gov.uk/help/accessibility" class="govuk-link">@messages("compliant.one.p1.2")</a>
+        @messages("compliant.one.p1.3")
+    </p>
+
+    <p class="govuk-body">@messages("compliant.one.p2")</p>
+
+    <h2 class="govuk-heading-l">@messages("compliant.two.heading")</h2>
+
+    <p class="govuk-body">@messages("compliant.two.p1")</p>
+    <p class="govuk-body">@messages("compliant.two.p2")</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>@messages("compliant.two.l1")</li>
+        <li>@messages("compliant.two.l2")</li>
+        <li>@messages("compliant.two.l3")</li>
+        <li>@messages("compliant.two.l4")</li>
+        <li>@messages("compliant.two.l5")</li>
+    </ul>
+
+    <p class="govuk-body">@messages("compliant.two.p3")</p>
+
+    <p class="govuk-body">@messages("compliant.two.p4.0")
+        <a href="https://mcmw.abilitynet.org.uk/" class="govuk-link">@messages("compliant.two.p4.1")</a>
+        @messages("compliant.two.p4.2")
+    </p>
+    <h2 class="govuk-heading-l">@messages("compliant.three.heading")</h2>
+
+    <p class="govuk-body">@messages("compliant.three.p1.1")
+        <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">@messages("compliant.three.p1.2")</a>.
+        @messages("compliant.three.p1.3")
+    </p>
+
+    <h2 class="govuk-heading-l">@messages("compliant.five.heading")</h2>
+
+    <p class="govuk-body">@messages("compliant.five.p.1")
+        <a href="https://www.tax.service.gov.uk/contact/accessibility-unauthenticated?service=jrsc" class="govuk-link" target=".blank">@messages("compliant.five.p.2")</a>.
+    </p>
+
+    <h2 class="govuk-heading-l">@messages("compliant.six.heading")</h2>
+
+    <p class="govuk-body">
+        @messages("compliant.six.p.1")
+        <a href="https://www.equalityadvisoryservice.com/" class="govuk-link">@messages("compliant.six.p.2")</a>
+        @messages("compliant.six.p.3")
+        <a href="https://www.equalityni.org/Home" class="govuk-link">@messages("compliant.six.p.4")</a>
+        @messages("compliant.six.p.5")
+    </p>
+
+    <h2 class="govuk-heading-l">@messages("compliant.seven.heading")</h2>
+
+    <p class="govuk-body">@messages("compliant.seven.p1")</p>
+
+    <p class="govuk-body">@messages("compliant.seven.p2")</p>
+
+    <p class="govuk-body">@messages("compliant.seven.p3.1")
+        <a href="https://www.gov.uk/dealing-hmrc-additional-needs" class="govuk-link">@messages("compliant.seven.p3.2")</a>.
+    </p>
+
+    <h2 class="govuk-heading-l">@messages("compliant.eight.heading")</h2>
+
+    <p class="govuk-body">@messages("compliant.eight.p1")</p>
+
+    <p class="govuk-body">@messages("compliant.eight.p2.1")
+        <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">@messages("compliant.eight.p2.2")</a>.
+    </p>
+
+    <h2 class="govuk-heading-l">@messages("compliant.nine.heading")</h2>
+
+    <p class="govuk-body">@messages("compliant.nine.p1")</p>
+
+    <p class="govuk-body">@messages("compliant.nine.p2.1")
+        <a href="http://www.digitalaccessibilitycentre.org/" class="govuk-link">@messages("compliant.nine.p2.2")</a>.
+        @messages("compliant.nine.p2.3")
+    </p>
+
+    <p class="govuk-body">@messages("compliant.nine.p3")</p>
+
+}
+@{
+    //$COVERAGE-OFF$
+}

--- a/app/views/accessibility_statement.scala.html
+++ b/app/views/accessibility_statement.scala.html
@@ -14,11 +14,9 @@
  * limitations under the License.
  *@
 
-@import config.AppConfig
-
 @this(layout: main_layout)
 
-@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@()(implicit request: Request[_], messages: Messages)
 
 @layout(messages("accessibility.title")) {
     <h1 class="govuk-heading-xl">@messages("compliant.one.heading")</h1>

--- a/app/views/components/FooterLinks.scala
+++ b/app/views/components/FooterLinks.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import config.AppConfig
+import controllers.routes
+import javax.inject.Inject
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.footer.FooterItem
+
+class FooterLinks @Inject()(appConfig: AppConfig) {
+
+  def cookieLink(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.cookies")),
+    Some(appConfig.cookies)
+  )
+
+  def privacyLink(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.privacy")),
+    Some(appConfig.privacy)
+  )
+
+  def termsConditionsLink(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.termsConditions")),
+    Some(appConfig.termsConditions)
+  )
+
+  def govukHelpLink(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.govukHelp")),
+    Some(appConfig.govukHelp)
+  )
+
+  def defaultLink(implicit messages: Messages): FooterItem = FooterItem (
+    Some("GOV.UK Prototype Kit v9.1.0"),
+    Some("https://govuk-prototype-kit.herokuapp.com/")
+  )
+
+  def accecssibilityLink(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.accessibility")),
+    Some(routes.AccessibilityStatementController.getPage().url)
+  )
+
+  def items(implicit messages: Messages): Seq[FooterItem] = Seq(
+    defaultLink,
+    accecssibilityLink,
+    cookieLink,
+    privacyLink,
+    termsConditionsLink,
+    govukHelpLink
+  )
+}

--- a/app/views/components/FooterLinks.scala
+++ b/app/views/components/FooterLinks.scala
@@ -22,7 +22,7 @@ import javax.inject.Inject
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.footer.FooterItem
 
-class FooterLinks @Inject()(appConfig: AppConfig) {
+class FooterLinks @Inject()(implicit appConfig: AppConfig) {
 
   def cookieLink(implicit messages: Messages): FooterItem = FooterItem(
     Some(messages("footer.cookies")),

--- a/app/views/components/FooterLinks.scala
+++ b/app/views/components/FooterLinks.scala
@@ -22,7 +22,7 @@ import javax.inject.Inject
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.footer.FooterItem
 
-class FooterLinks @Inject()(implicit appConfig: AppConfig) {
+class FooterLinks @Inject() (implicit appConfig: AppConfig) {
 
   def cookieLink(implicit messages: Messages): FooterItem = FooterItem(
     Some(messages("footer.cookies")),
@@ -44,7 +44,7 @@ class FooterLinks @Inject()(implicit appConfig: AppConfig) {
     Some(appConfig.govukHelp)
   )
 
-  def defaultLink(implicit messages: Messages): FooterItem = FooterItem (
+  def defaultLink(implicit messages: Messages): FooterItem = FooterItem(
     Some("GOV.UK Prototype Kit v9.1.0"),
     Some("https://govuk-prototype-kit.herokuapp.com/")
   )

--- a/app/views/components/FooterLinks.scala
+++ b/app/views/components/FooterLinks.scala
@@ -24,40 +24,34 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.footer.FooterItem
 
 class FooterLinks @Inject() (implicit appConfig: AppConfig) {
 
-  def cookieLink(implicit messages: Messages): FooterItem = FooterItem(
-    Some(messages("footer.cookies")),
+  def cookieLink()(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.links.cookies.text")),
     Some(appConfig.cookies)
   )
 
-  def privacyLink(implicit messages: Messages): FooterItem = FooterItem(
-    Some(messages("footer.privacy")),
+  def privacyLink()(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.links.privacy_policy.text")),
     Some(appConfig.privacy)
   )
 
-  def termsConditionsLink(implicit messages: Messages): FooterItem = FooterItem(
-    Some(messages("footer.termsConditions")),
+  def termsConditionsLink()(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.links.terms_and_conditions.text")),
     Some(appConfig.termsConditions)
   )
 
-  def govukHelpLink(implicit messages: Messages): FooterItem = FooterItem(
-    Some(messages("footer.govukHelp")),
+  def govukHelpLink()(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.links.help_page.text")),
     Some(appConfig.govukHelp)
   )
 
-  def defaultLink(implicit messages: Messages): FooterItem = FooterItem(
-    Some("GOV.UK Prototype Kit v9.1.0"),
-    Some("https://govuk-prototype-kit.herokuapp.com/")
-  )
-
-  def accecssibilityLink(implicit messages: Messages): FooterItem = FooterItem(
-    Some(messages("footer.accessibility")),
+  def accecssibilityLink()(implicit messages: Messages): FooterItem = FooterItem(
+    Some(messages("footer.links.accessibility.text")),
     Some(routes.AccessibilityStatementController.getPage().url)
   )
 
   def items(implicit messages: Messages): Seq[FooterItem] = Seq(
-    defaultLink,
-    accecssibilityLink,
     cookieLink,
+    accecssibilityLink,
     privacyLink,
     termsConditionsLink,
     govukHelpLink

--- a/app/views/main_layout.scala.html
+++ b/app/views/main_layout.scala.html
@@ -18,11 +18,13 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.header.Header
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Cy}
+@import views.components.FooterLinks
 
 @this(layout: GovukLayout,
         phaseBanner : GovukPhaseBanner,
         govUkHeader: GovukHeader,
-        hmrcLanguageSelect: HmrcLanguageSelect)
+        hmrcLanguageSelect: HmrcLanguageSelect,
+        footerLinks: FooterLinks)
 
 @(pageTitle: String, startUrl: Option[String] = None)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
@@ -63,9 +65,7 @@
     headBlock = Some(head),
     headerBlock = Some(headerBlock),
     beforeContentBlock = Some(beforeContentBlock),
-    footerItems = Seq(FooterItem(
-        href = Some("https://govuk-prototype-kit.herokuapp.com/"),
-        text = Some("GOV.UK Prototype Kit v9.1.0"))),
+    footerItems = footerLinks.items,
     bodyEndBlock = Some(scripts))(contentBlock)
 
 @{

--- a/app/views/main_layout.scala.html
+++ b/app/views/main_layout.scala.html
@@ -19,11 +19,13 @@
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Cy}
 @import views.components.FooterLinks
+@import config.AppConfig
 
 @this(layout: GovukLayout,
         phaseBanner : GovukPhaseBanner,
         govUkHeader: GovukHeader,
         hmrcLanguageSelect: HmrcLanguageSelect,
+        appConfig: AppConfig,
         footerLinks: FooterLinks)
 
 @(pageTitle: String, startUrl: Option[String] = None)(contentBlock: Html)(implicit request: Request[_], messages: Messages)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,6 +14,8 @@ GET   /start/:processId                  controllers.GuidanceController.startJou
 
 GET   /published/:processId              controllers.GuidanceController.published(processId)
 
+GET   /accessibility                     controllers.AccessibilityStatementController.getPage
+
 GET   /*path                             controllers.GuidanceController.getPage(path: String)
 POST  /*path                             controllers.GuidanceController.submitPage(path: String)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -128,7 +128,13 @@ mongo-async-driver {
 }
 
 urls {
-   baseUrl = "/guidance"
-   externalGuidanceScratchUrl = "/external-guidance/scratch"
+  baseUrl = "/guidance"
+  externalGuidanceScratchUrl = "/external-guidance/scratch"
+  footer {
+    govukHelp       = "https://www.gov.uk/help"
+    termsConditions = "https://www.tax.service.gov.uk/help/terms-and-conditions"
+    privacy         = "https://www.tax.service.gov.uk/help/privacy"
+    cookies         = "https://www.tax.service.gov.uk/help/cookies"
+  }
 }
 

--- a/conf/messages
+++ b/conf/messages
@@ -1,0 +1,5 @@
+footer.accessibility   = Accessibility Statement
+footer.cookies         = Cookies
+footer.privacy         = Privacy policy
+footer.termsConditions = Terms and conditions
+footer.govukHelp       = Help using GOV.UK

--- a/conf/messages
+++ b/conf/messages
@@ -1,5 +1,5 @@
-footer.accessibility   = Accessibility Statement
-footer.cookies         = Cookies
-footer.privacy         = Privacy policy
-footer.termsConditions = Terms and conditions
-footer.govukHelp       = Help using GOV.UK
+footer.links.help_page.text=Help using GOV.UK
+footer.links.cookies.text=Cookies
+footer.links.accessibility.text=Accessibility
+footer.links.privacy_policy.text=Privacy policy
+footer.links.terms_and_conditions.text=Terms and conditions

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -6,6 +6,14 @@ site.continue = Parhewch
 
 error.browser.title.prefix = Gwall:
 
+# Footer Links
+# ----------------------------------------------------------
+footer.links.help_page.text=Help wrth ddefnyddio GOV.UK
+footer.links.cookies.text=Cwcis
+footer.links.accessibility.text=Hygyrchedd
+footer.links.privacy_policy.text=Polisi preifatrwydd
+footer.links.terms_and_conditions.text=Telerau ac Amodau
+
 # Compliance statement
 # ----------------------------------------------------------
 accessibility.title=Datganiad hygyrchedd ar gyfer Canllawiau Allanol - i'w Ddiffinio

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -5,3 +5,70 @@ hello.world.currentLanguage = Y gosodiad iaith cyfredol yw "{0}",
 site.continue = Parhewch
 
 error.browser.title.prefix = Gwall:
+
+# Compliance statement
+# ----------------------------------------------------------
+accessibility.title=Datganiad hygyrchedd ar gyfer Canllawiau Allanol - i'w Ddiffinio
+
+## section one
+compliant.one.heading=Datganiad hygyrchedd ar gyfer Canllawiau Allanol - i'w Ddiffinio
+compliant.one.lede=This accessibility statement explains how accessible this service is, what to do if you have difficulty using it, and how to report accessibility problems with the service.
+compliant.one.p1.1=This service is part of the wider GOV.UK website. There is a separate
+compliant.one.p1.2=accessibility statement
+compliant.one.p1.3=for the main GOV.UK website.
+compliant.one.p2=This page only contains information about the External Guidance service, available at www<to be defined>/guidance
+
+## section two
+compliant.two.heading=Using this service
+compliant.two.p1=Info on service will go here
+compliant.two.p2=This service is run by HM Revenue and Customs (HMRC). We want as many people as possible to be able to use this service. This means you should be able to:
+compliant.two.l1=change colours, contrast levels and fonts
+compliant.two.l2=zoom in up to 300% without the text spilling off the screen
+compliant.two.l3=get from the start of the service to the end using just a keyboard
+compliant.two.l4=get from the start of the service to the end using speech recognition software
+compliant.two.l5=listen to the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+compliant.two.p3=We have also made the text in the service as simple as possible to understand.
+compliant.two.p4.0=
+compliant.two.p4.1=AbilityNet
+compliant.two.p4.2=has advice on making your device easier to use if you have a disability.
+
+## section three
+compliant.three.heading=How accessible this service is
+compliant.three.p1.1=This service is partially compliant with the
+compliant.three.p1.2=Web Content Accessibility Guidelines version 2.1 AA standard
+compliant.three.p1.3=We cannot be certain that it is fully compliant until it is fully tested, which will be within one week of its launch date of 20 April 2020.
+
+## section five
+compliant.five.heading=Reporting accessibility problems with this service
+compliant.five.p.1=We are always looking to improve the accessibility of this service. If you find any problems that are not listed on this page or think we are not meeting accessibility requirements, report the
+compliant.five.p.2=accessibility problem (opens in a new window or tab)
+
+## section six
+compliant.six.heading=What to do if you are not happy with how we respond to your complaint
+compliant.six.p.1=The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you are not happy with how we respond to your complaint,
+compliant.six.p.2=contact the Equality Advisory and Support Service
+compliant.six.p.3=(EASS), or the
+compliant.six.p.4=Equality Commission for Northern Ireland
+compliant.six.p.5=(ECNI) if you live in Northern Ireland.
+
+## section seven
+compliant.seven.heading=Contacting us by phone or getting a visit from us in person
+compliant.seven.p1=We provide a text relay service if you are deaf, hearing impaired or have a speech impediment.
+compliant.seven.p2=We can provide a British Sign Language (BSL) interpreter, or you can arrange a visit from an HMRC advisor to help you complete the service.
+compliant.seven.p3.1=Find out how to
+compliant.seven.p3.2=contact us
+
+## section eight
+compliant.eight.heading=Technical information about this service’s accessibility
+compliant.eight.p1=HMRC is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+compliant.eight.p2.1=This service is fully compliant with the
+compliant.eight.p2.2=Web Content Accessibility Guidelines version 2.1 AA standard
+
+## section nine
+compliant.nine.heading=How we tested this service
+compliant.nine.p1=The service was launched on 20 April 2020 and checked for compliance with WCAG 2.1 AA.
+compliant.nine.p2.1=The service was built using parts that were tested by the
+compliant.nine.p2.2=Digital Accessibility Centre
+compliant.nine.p2.3=The full service will be tested by HMRC within a week of the launch date. Tests will include disabled users.
+compliant.nine.p3=This page was prepared on 17 April 2020. It was last updated on 20 April 2020.
+

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -5,3 +5,70 @@ hello.world.currentLanguage = The current language setting is "{0}",
 site.continue = Continue
 
 error.browser.title.prefix = Error:
+
+# Compliance statement
+# ----------------------------------------------------------
+accessibility.title=Accessibility statement for External Guidance - to Be Defined
+
+## section one
+compliant.one.heading=Accessibility statement for External Guidance - to Be Defined
+compliant.one.lede=This accessibility statement explains how accessible this service is, what to do if you have difficulty using it, and how to report accessibility problems with the service.
+compliant.one.p1.1=This service is part of the wider GOV.UK website. There is a separate
+compliant.one.p1.2=accessibility statement
+compliant.one.p1.3=for the main GOV.UK website.
+compliant.one.p2=This page only contains information about the External Guidance service, available at www<to be defined>/guidance
+
+## section two
+compliant.two.heading=Using this service
+compliant.two.p1=Info on service will go here
+compliant.two.p2=This service is run by HM Revenue and Customs (HMRC). We want as many people as possible to be able to use this service. This means you should be able to:
+compliant.two.l1=change colours, contrast levels and fonts
+compliant.two.l2=zoom in up to 300% without the text spilling off the screen
+compliant.two.l3=get from the start of the service to the end using just a keyboard
+compliant.two.l4=get from the start of the service to the end using speech recognition software
+compliant.two.l5=listen to the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+compliant.two.p3=We have also made the text in the service as simple as possible to understand.
+compliant.two.p4.0=
+compliant.two.p4.1=AbilityNet
+compliant.two.p4.2=has advice on making your device easier to use if you have a disability.
+
+## section three
+compliant.three.heading=How accessible this service is
+compliant.three.p1.1=This service is partially compliant with the
+compliant.three.p1.2=Web Content Accessibility Guidelines version 2.1 AA standard
+compliant.three.p1.3=We cannot be certain that it is fully compliant until it is fully tested, which will be within one week of its launch date of 20 April 2020.
+
+## section five
+compliant.five.heading=Reporting accessibility problems with this service
+compliant.five.p.1=We are always looking to improve the accessibility of this service. If you find any problems that are not listed on this page or think we are not meeting accessibility requirements, report the
+compliant.five.p.2=accessibility problem (opens in a new window or tab)
+
+## section six
+compliant.six.heading=What to do if you are not happy with how we respond to your complaint
+compliant.six.p.1=The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you are not happy with how we respond to your complaint,
+compliant.six.p.2=contact the Equality Advisory and Support Service
+compliant.six.p.3=(EASS), or the
+compliant.six.p.4=Equality Commission for Northern Ireland
+compliant.six.p.5=(ECNI) if you live in Northern Ireland.
+
+## section seven
+compliant.seven.heading=Contacting us by phone or getting a visit from us in person
+compliant.seven.p1=We provide a text relay service if you are deaf, hearing impaired or have a speech impediment.
+compliant.seven.p2=We can provide a British Sign Language (BSL) interpreter, or you can arrange a visit from an HMRC advisor to help you complete the service.
+compliant.seven.p3.1=Find out how to
+compliant.seven.p3.2=contact us
+
+## section eight
+compliant.eight.heading=Technical information about this service’s accessibility
+compliant.eight.p1=HMRC is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+compliant.eight.p2.1=This service is fully compliant with the
+compliant.eight.p2.2=Web Content Accessibility Guidelines version 2.1 AA standard
+
+## section nine
+compliant.nine.heading=How we tested this service
+compliant.nine.p1=The service was launched on 20 April 2020 and checked for compliance with WCAG 2.1 AA.
+compliant.nine.p2.1=The service was built using parts that were tested by the
+compliant.nine.p2.2=Digital Accessibility Centre
+compliant.nine.p2.3=The full service will be tested by HMRC within a week of the launch date. Tests will include disabled users.
+compliant.nine.p3=This page was prepared on 17 April 2020. It was last updated on 20 April 2020.
+

--- a/it/pages/AccessibilityStatementControllerISpec.scala
+++ b/it/pages/AccessibilityStatementControllerISpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pages
+
+import play.api.http.Status
+import play.api.libs.ws.{WSRequest, WSResponse}
+import stubs.AuditStub
+import support.IntegrationSpec
+
+class AccessibilityStatementControllerISpec extends IntegrationSpec {
+
+  "calling the accessibility route" should {
+
+    "return an OK response" in {
+
+      AuditStub.audit()
+
+      val request: WSRequest = buildRequest("/guidance/accessibility")
+
+      val response: WSResponse = await(request.get())
+
+      response.status shouldBe Status.OK
+
+    }
+
+  }
+
+}

--- a/test/controllers/AccessibilityStatementControllerSpec.scala
+++ b/test/controllers/AccessibilityStatementControllerSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.AppConfigImpl
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.Status
+import play.api.mvc.{AnyContentAsEmpty, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.{Configuration, Environment, _}
+import uk.gov.hmrc.play.bootstrap.config.{RunMode, ServicesConfig}
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+import scala.concurrent.Future
+
+class AccessibilityStatementControllerSpec extends WordSpec with Matchers with GuiceOneAppPerSuite {
+
+  private trait Test {
+    val fakeRequest = FakeRequest("GET", "/")
+
+    private val env = Environment.simple()
+    private val configuration = Configuration.load(env)
+
+    private val serviceConfig = new ServicesConfig(configuration, new RunMode(configuration, Mode.Dev))
+    private val appConfig = new AppConfigImpl(configuration, serviceConfig)
+
+    private val view = app.injector.instanceOf[views.html.accessibility_statement]
+    val controller = new AccessibilityStatementController(appConfig, stubMessagesControllerComponents(), view)
+  }
+
+  "GET /accessibility" should {
+    "return 200" in new Test {
+      val result: Future[Result] = controller.getPage(fakeRequest)
+      status(result) shouldBe Status.OK
+    }
+
+    "return HTML" in new Test {
+      val result: Future[Result] = controller.getPage(fakeRequest)
+      contentType(result) shouldBe Some("text/html")
+      charset(result) shouldBe Some("utf-8")
+
+    }
+
+  }
+
+}

--- a/test/controllers/AccessibilityStatementControllerSpec.scala
+++ b/test/controllers/AccessibilityStatementControllerSpec.scala
@@ -16,15 +16,13 @@
 
 package controllers
 
-import config.AppConfigImpl
+import mocks.MockAppConfig
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
-import play.api.mvc.{AnyContentAsEmpty, Result}
+import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.api.{Configuration, Environment, _}
-import uk.gov.hmrc.play.bootstrap.config.{RunMode, ServicesConfig}
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 import scala.concurrent.Future
@@ -34,14 +32,8 @@ class AccessibilityStatementControllerSpec extends WordSpec with Matchers with G
   private trait Test {
     val fakeRequest = FakeRequest("GET", "/")
 
-    private val env = Environment.simple()
-    private val configuration = Configuration.load(env)
-
-    private val serviceConfig = new ServicesConfig(configuration, new RunMode(configuration, Mode.Dev))
-    private val appConfig = new AppConfigImpl(configuration, serviceConfig)
-
     private val view = app.injector.instanceOf[views.html.accessibility_statement]
-    val controller = new AccessibilityStatementController(appConfig, stubMessagesControllerComponents(), view)
+    val controller = new AccessibilityStatementController(MockAppConfig, stubMessagesControllerComponents(), view)
   }
 
   "GET /accessibility" should {

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -31,4 +31,9 @@ object MockAppConfig extends AppConfig {
   override val reportAProblemNonJSUrl: String = "someJsUrl"
   override val externalGuidanceBaseUrl: String = "http://external-guidance-base-url"
   override val sessionProcessTTLMinutes: Int = 20
+  override val cookies: String = "someUrl"
+  override val privacy: String = "someUrl"
+  override val termsConditions: String = "someUrl"
+  override val govukHelp: String = "someUrl"
+
 }

--- a/test/services/GuidanceServiceSpec.scala
+++ b/test/services/GuidanceServiceSpec.scala
@@ -178,5 +178,4 @@ class GuidanceServiceSpec extends BaseSpec {
     }
   }
 
-
 }

--- a/test/services/PageBuilderSpec.scala
+++ b/test/services/PageBuilderSpec.scala
@@ -397,7 +397,6 @@ class PageBuilderSpec extends BaseSpec with ProcessJson with StanzaHelper {
 
       }
 
-
       "correctly identify the pages in a Process accounting fro every stanza" in {
 
         val process: Process = prototypeJson.as[Process]

--- a/test/views/components/PageSpec.scala
+++ b/test/views/components/PageSpec.scala
@@ -19,12 +19,12 @@ package views.components
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.Injector
-import play.api.i18n.{Messages, MessagesApi, Lang}
+import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import org.jsoup.Jsoup
 import views.html.standard_page
-import models.ui.{BulletPointList, Page, H1, Paragraph, Text, StandardPage}
+import models.ui.{BulletPointList, H1, Page, Paragraph, StandardPage, Text}
 import org.jsoup.nodes.Document
 import scala.collection.JavaConverters._
 
@@ -84,8 +84,8 @@ class PageSpec extends WordSpec with Matchers with GuiceOneAppPerSuite {
 
       val secondPara = paras.eq(3)
       secondPara.first.text shouldBe bulletPointLeadingText.english.head.toString
-
-      val actualListItems = doc.getElementsByTag("li").asScala.toList.dropRight(1)
+      // Need to ignore the footer <li> elements
+      val actualListItems = doc.select("ul.govuk-list--bullet > li").asScala.toList
       actualListItems.size shouldBe 3
 
       val expectedListItems: List[String] =
@@ -112,7 +112,8 @@ class PageSpec extends WordSpec with Matchers with GuiceOneAppPerSuite {
       val secondPara = paras.eq(3)
       secondPara.first.text shouldBe bulletPointLeadingText.welsh.head.toString
 
-      val actualListItems = doc.getElementsByTag("li").asScala.toList.dropRight(1)
+      // Need to ignore the footer <li> elements
+      val actualListItems = doc.select("ul.govuk-list--bullet > li").asScala.toList
       actualListItems.size shouldBe 3
 
       val expectedListItems: List[String] = List(bulletPointOne.welsh.head.toString, bulletPointTwo.welsh.head.toString, bulletPointThree.welsh.head.toString)

--- a/test/views/components/QuestionSpec.scala
+++ b/test/views/components/QuestionSpec.scala
@@ -82,7 +82,7 @@ class QuestionSpec extends WordSpec with Matchers with GuiceOneAppPerSuite {
     "render contained paragraphs" in new Test {
       val doc = asDocument(components.question(question, "test")(fakeRequest, messages))
 
-      doc.getElementsByTag("p").asScala.toList.foreach{ p =>
+      doc.getElementsByTag("p").asScala.toList.foreach { p =>
         elementAttrs(p)("class").contains("govuk-body") shouldBe true
       }
     }
@@ -153,7 +153,7 @@ class QuestionSpec extends WordSpec with Matchers with GuiceOneAppPerSuite {
     "render contained paragraphs" in new WelshTest {
       val doc = asDocument(components.question(question, "test")(fakeRequest, messages))
 
-      doc.getElementsByTag("p").asScala.toList.foreach{ p =>
+      doc.getElementsByTag("p").asScala.toList.foreach { p =>
         elementAttrs(p)("class").contains("govuk-body") shouldBe true
       }
     }


### PR DESCRIPTION
Code changes for Accessibility Statement Page - available via links in the footer.  Added placeholders for other standard looking footer items that can be updated via AppConfig and new FooterLinks class.
Change to PageSpec test class due to footer changes adding additional <li> tags which this test looks for.
Some additional classes updated purely as part of running scalafmtAll 