### PR TITLE
EG-987 - Asset path

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
 $govuk-assets-path: "/guidance/assets/lib/govuk-frontend/govuk/assets/";
-$hmrc-assets-path: "/guidance/assets/lib/hmrc-frontend/hmrc/assets/";
+$hmrc-assets-path: "/guidance/assets/lib/hmrc-frontend/hmrc/";
 
 $govuk-global-styles: true;
 


### PR DESCRIPTION
Changing asset path for hmrc-assets-path to fix asset issue that means favico is not displayed