### PR TITLE
EG-1124 - Change NotFound error received from eg to return a 404 to viewer

### DIFF
--- a/app/connectors/httpParsers/GetProcessHttpParser.scala
+++ b/app/connectors/httpParsers/GetProcessHttpParser.scala
@@ -16,7 +16,7 @@
 
 package connectors.httpParsers
 
-import models.errors.{InternalServerError, InvalidProcessError}
+import models.errors.{InternalServerError, InvalidProcessError, NotFoundError}
 import models.ocelot._
 import models.RequestOutcome
 import play.api.Logger
@@ -35,7 +35,7 @@ object GetProcessHttpParser extends HttpParser {
           Left(InternalServerError)
       }
     case (_, _, response) if response.status == NOT_FOUND =>
-      Left(InvalidProcessError)
+      Left(NotFoundError)
     case (_, _, response) if response.status == BAD_REQUEST =>
       Left(InvalidProcessError)
     case unknown =>

--- a/app/services/GuidanceService.scala
+++ b/app/services/GuidanceService.scala
@@ -143,7 +143,7 @@ class GuidanceService @Inject() (
   ): Future[RequestOutcome[(String,String)]] =
     retrieveProcessById(processIdentifier).flatMap {
       case Left(err) =>
-        logger.warn(s"Unable to find process using identifier $processIdentifier, error")
+        logger.warn(s"Unable to find process using identifier $processIdentifier, received $err")
         Future.successful(Left(err))
 
       case Right(process) =>

--- a/test/connectors/httpParsers/GetProcessHttpParserSpec.scala
+++ b/test/connectors/httpParsers/GetProcessHttpParserSpec.scala
@@ -21,7 +21,7 @@ import play.api.http.{HttpVerbs, Status}
 import play.api.libs.json.{Json, JsValue, JsObject, JsNull}
 import uk.gov.hmrc.http.HttpResponse
 import models.RequestOutcome
-import models.errors.{InvalidProcessError, InternalServerError}
+import models.errors._
 import models.ocelot.Process
 import base.BaseSpec
 
@@ -62,7 +62,7 @@ class GetProcessHttpParserSpec extends BaseSpec with HttpVerbs with Status {
       val result: RequestOutcome[Process] =
         getProcessHttpReads.read(GET, url, httpResponse)
 
-      result shouldBe Left(InvalidProcessError)
+      result shouldBe Left(NotFoundError)
     }
 
     "return an invalid process error for a bad request" in new Test {


### PR DESCRIPTION
This will stop PagerDuty incorrectly reporting internal server error for a standard 404