### PR TITLE
Dl 10393

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import scala.collection.immutable.ListMap
 
 trait AppConfig {
-  val assetsPrefix: String
   val analyticsToken: String
   val analyticsHost: String
   val reportAProblemPartialUrl: String
@@ -60,12 +59,10 @@ class AppConfigImpl @Inject() (val config: Configuration, servicesConfig: Servic
   val EndSessionURL = "/end-session"
   val PageStanzaCountLimit = 1000
   private val contactBaseUrl = servicesConfig.baseUrl("contact-frontend")
-  private val assetsUrl = config.get[String]("assets.url")
   lazy val host: String = servicesConfig.getString("host")
   lazy val adminHost: String = servicesConfig.getString("adminHost")
   lazy val betaFeedback: String = servicesConfig.getString("betafeedback")
 
-  val assetsPrefix: String = assetsUrl + config.get[String]("assets.version")
   val analyticsToken: String = config.get[String](s"google-analytics.token")
   val analyticsHost: String = config.get[String](s"google-analytics.host")
   val reportAProblemPartialUrl: String = s"$contactBaseUrl/contact/problem_reports_ajax?service=$serviceIdentifier"

--- a/app/controllers/GuidanceController.scala
+++ b/app/controllers/GuidanceController.scala
@@ -17,28 +17,26 @@
 package controllers
 
 import config.{AppConfig, ErrorHandler}
-
-import javax.inject.{Inject, Singleton}
-import play.api.i18n.Messages
-import play.api.mvc._
-import play.api.data.Form
-import services.{ErrorStrategy, GuidanceService, ValueTypeError, ValueTypeGroupError}
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import controllers.actions.SessionIdAction
 import core.models.RequestOutcome
 import core.models.errors._
 import core.models.ocelot.errors.RuntimeError
 import core.models.ocelot.stanzas.DateInput
-import core.models.ocelot.{RunMode, Published, SecuredProcess}
-import models.{PageContext, PageEvaluationContext}
-import models.ui.{FormPage, StandardPage, SubmittedAnswer}
-import views.html.{form_page, standard_page}
-import play.api.Logger
-import models.GuidanceSession
-import scala.concurrent.ExecutionContext.Implicits.global
-import controllers.actions.SessionIdAction
-import play.twirl.api.Html
-import scala.concurrent.Future
+import core.models.ocelot.{Published, RunMode, SecuredProcess}
 import forms.FormProviderFactory
+import models.ui.{FormPage, StandardPage, SubmittedAnswer}
+import models.{GuidanceSession, PageContext, PageEvaluationContext}
+import play.api.Logger
+import play.api.data.Form
+import play.api.i18n.Messages
+import play.api.mvc._
+import play.twirl.api.Html
+import services.{ErrorStrategy, GuidanceService, ValueTypeError, ValueTypeGroupError}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.{form_page, standard_page}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class GuidanceController @Inject() (
@@ -50,7 +48,7 @@ class GuidanceController @Inject() (
     service: GuidanceService,
     mcc: MessagesControllerComponents,
     formProvider: FormProviderFactory
-) extends FrontendController(mcc)
+)(implicit ec: ExecutionContext) extends FrontendController(mcc)
   with SessionFrontendController {
 
   val logger: Logger = Logger(getClass)

--- a/app/controllers/SessionTimeoutPageController.scala
+++ b/app/controllers/SessionTimeoutPageController.scala
@@ -16,19 +16,18 @@
 
 package controllers
 
-import play.twirl.api.Html
 import config.{AppConfig, ErrorHandler}
-import javax.inject.{Inject, Singleton}
 import core.models.errors.SessionNotFoundError
 import play.api.Logger
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc._
+import play.twirl.api.Html
 import services.GuidanceService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import views.html.{user_deleted_session, system_timedout_session}
+import views.html.{system_timedout_session, user_deleted_session}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class SessionTimeoutPageController @Inject()(appConfig: AppConfig,
@@ -37,7 +36,7 @@ class SessionTimeoutPageController @Inject()(appConfig: AppConfig,
                                              mcc: MessagesControllerComponents,
                                              system_timedout_session_view: system_timedout_session,
                                              user_deleted_session_view: user_deleted_session
-                                             )
+                                             )(implicit ec: ExecutionContext)
   extends FrontendController(mcc)
   with I18nSupport {
 

--- a/app/controllers/entry/StartAdminController.scala
+++ b/app/controllers/entry/StartAdminController.scala
@@ -17,20 +17,20 @@
 package controllers.entry
 
 import config.ErrorHandler
-import javax.inject.{Inject, Singleton}
+import core.models.RequestOutcome
+import core.models.errors.NotFoundError
+import core.models.ocelot.stanzas._
+import core.models.ocelot.{Page, Process, SecuredProcess}
+import models.admin._
+import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.RetrieveAndCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import play.api.Logger
-import scala.concurrent.ExecutionContext.Implicits.global
-import models.admin._
-import core.models.RequestOutcome
 import views.html._
-import core.models.errors.NotFoundError
-import core.models.ocelot.{Process, Page, SecuredProcess}
-import core.models.ocelot.stanzas.{TitleCallout, Input, YourCallCallout, Question, Sequence}
-import scala.concurrent.Future
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class StartAdminController @Inject() (
@@ -38,7 +38,7 @@ class StartAdminController @Inject() (
     service: RetrieveAndCacheService,
     view: admin.process_map,
     mcc: MessagesControllerComponents
-) extends FrontendController(mcc)
+)(implicit ec: ExecutionContext) extends FrontendController(mcc)
     with I18nSupport {
 
   val logger: Logger = Logger(getClass)

--- a/app/controllers/entry/StartGuidanceController.scala
+++ b/app/controllers/entry/StartGuidanceController.scala
@@ -17,21 +17,19 @@
 package controllers.entry
 
 import config.{AppConfig, ErrorHandler}
-import javax.inject.{Inject, Singleton}
+import controllers.actions.SessionIdAction
+import controllers.{SessionIdPrefix, validateUrl}
+import core.models.RequestOutcome
+import core.models.errors._
+import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.RetrieveAndCacheService
+import uk.gov.hmrc.http.{HeaderNames, SessionKeys}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import core.models.errors._
-import core.models.RequestOutcome
-import play.api.Logger
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
-import controllers.SessionIdPrefix
-import controllers.actions.SessionIdAction
-import controllers.validateUrl
-import uk.gov.hmrc.http.SessionKeys
-import uk.gov.hmrc.http.HeaderNames
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class StartGuidanceController @Inject() (
@@ -40,7 +38,7 @@ class StartGuidanceController @Inject() (
     sessionIdAction: SessionIdAction,
     mcc: MessagesControllerComponents,
     appConfig: AppConfig
-) extends FrontendController(mcc)
+)(implicit ec: ExecutionContext) extends FrontendController(mcc)
     with I18nSupport {
 
   val logger: Logger = Logger(getClass)

--- a/app/repositories/SessionFSM.scala
+++ b/app/repositories/SessionFSM.scala
@@ -43,8 +43,14 @@ class SessionFSM @Inject() () {
       // Initial page
       case Nil => (None, Some(List(PageHistory(url, Nil))), None, Nil)
 
-      // REFRESH: new url equals current url
+      // REFRESH: new url equals current url with same flowPath
       case x :: xs if x.url == url => (xs.headOption.map(_.url), None, None, Nil)
+
+      // This identifies refresh when back is not possible i.e. current and previous page have same url and flowPath. However a refresh
+      // where the current url is the same as the previous and the flowPaths are different will be missed and interpretted as a BACK
+      // Real soln is to ensure all URLs are unique by including the Sequence label value in the URL
+      //case x :: Nil if x.url == url => (None, None, None, Nil)
+      //case x :: y :: xs if x.url == url && flowPath(x.flowStack).equals(flowPath(y.flowStack)) => (xs.headOption.map(_.url), None, None, Nil)
 
       // BACK: new url equals previous url and prior flowStack equals the previous flowStack
       case _ :: y :: xs if y.url == url && !forceForward && priorSp.flowStack == y.flowStack =>

--- a/app/services/GuidanceService.scala
+++ b/app/services/GuidanceService.scala
@@ -27,7 +27,7 @@ import core.models.RequestOutcome
 import play.api.i18n.{MessagesApi, Messages}
 import scala.concurrent.{ExecutionContext, Future}
 import repositories.{SessionFSM, SessionRepository}
-import core.models.ocelot.{LabelCache, Labels, Process, Label}
+import core.models.ocelot.{LabelCache, Labels, Process, Label, flowPath}
 import core.models.ocelot.SecuredProcess
 
 @Singleton
@@ -163,7 +163,7 @@ class GuidanceService @Inject() (
         val requestId: Option[String] = hc.requestId.map(_.value)
         optionalNext.fold[Future[RequestOutcome[(Option[String], Labels)]]](Future.successful(Right((None, labels)))){next =>
           logger.debug(s"Next page found at stanzaId: $next")
-          sessionRepository.updateAfterFormSubmission(ctx.sessionId, ctx.processCode, url, submittedAnswer, labels, List(next), requestId).map{
+          sessionRepository.updateAfterFormSubmission(ctx.sessionId, ctx.processCode, answerStorageId(ctx.labels, url), submittedAnswer, labels, List(next), requestId).map{
             case Left(NotFoundError) =>
               logger.warn(s"TRANSACTION FAULT(Recoverable): saveFormPageState _id=${ctx.sessionId}, url: $url, answer: $validatedAnswer, requestId: ${requestId}")
               Left(TransactionFaultError)
@@ -207,13 +207,15 @@ class GuidanceService @Inject() (
               Right(
                 PageEvaluationContext(
                   page, visualStanzas, dataInput, sessionId, pageMapById, gs.process.startUrl.map(_ => s"${appConfig.baseUrl}/${processCode}/session-restart"),
-                  processTitle, gs.process.meta.id, processCode, updatedLabels, gs.backLink.map(bl => s"${appConfig.baseUrl}/$bl"), gs.answers.get(url),
+                  processTitle, gs.process.meta.id, processCode, updatedLabels, gs.backLink.map(bl => s"${appConfig.baseUrl}/$bl"), gs.answers.get(answerStorageId(updatedLabels, url)),
                   gs.process.betaPhaseBanner
                 )
               )
           }
         })
     }
+
+  private def answerStorageId(labels: Labels, url: String): String = flowPath(labels.flowStack).fold(url)(fp => s"${fp.replaceAll("[ .]", "_")}-$url")
 
   private def isAuthenticationUrl(url: String): Boolean = url.drop(1).equals(SecuredProcess.SecuredProcessStartUrl)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,13 +17,7 @@ include "frontend.conf"
 appName = "view-external-guidance-frontend"
 play.http.router  = prod.Routes
 
-# An ApplicationLoader that uses Guice to bootstrap the application.
-play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
-
 play.filters.csp.CSPFilter =  "script-src 'self' 'unsafe-inline' www.googletagmanager.com www.google-analytics.com tagmanager.google.com data:; style-src 'self' 'unsafe-inline' fonts.googleapis.com tagmanager.google.com www.google-analytics.com; img-src 'self' www.google-analytics.com www.googletagmanager.com ssl.gstatic.com www.gstatic.com lh3.googleusercontent.com data:; font-src 'self' ssl.gstatic.com www.gstatic.com fonts.gstatic.com fonts.googleapis.com; frame-src 'self' www.googletagmanager.com www.google-analytics.com; object-src ; "
-
-# Primary entry point for all HTTP requests on Play applications
-play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
 # Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
@@ -67,14 +61,7 @@ play.i18n.langs = ["en", "cy"]
 # play.crypto.secret="xEvqVPjd3vWvIQMYGxecPg1Ao1XthFQvoH8yjSmwgJRaEI1eVYmydOJP3gIfLjD5"
 
 microservice {
-  metrics {
-    graphite {
-      host = localhost
-      port = 2003
-      prefix = play.${appName}.
-      enabled = true
-    }
-  }
+  metrics.graphite.enabled = true
 
   services {
     contact-frontend {
@@ -91,35 +78,12 @@ microservice {
   }
 }
 
-metrics {
-  name = ${appName}
-  rateUnit = SECONDS
-  durationUnit = SECONDS
-  showSamples = true
-  jvm = true
-  enabled = false
-}
+auditing.enabled = true
 
-auditing {
-  enabled = true
-  traceRequests = true
-  consumer {
-    baseUri {
-      host = localhost
-      port = 8100
-    }
-  }
-}
 
 google-analytics {
   token = N/A
   host = auto
-}
-
-assets {
-  version = "3.11.0"
-  version = ${?ASSETS_FRONTEND_VERSION}
-  url = "http://localhost:9032/assets/"
 }
 
 mongodb {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -41,6 +41,8 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 
+play.filters.disabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFilter"
+
 # Prevent SessionTimeoutFilter from removing EG_NEW_SESSIONID when encountered
 session.additionalSessionKeysToKeep = ["EG_NEW_SESSIONID", "GUIDANCE_START"]
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,19 +5,19 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % "0.74.0",
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.25.0",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "6.3.0-play-28"
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "7.18.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "7.12.0-play-28"
   )
 
   val test = Seq(
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-test-play-28"    % "0.74.0"        % "test",
     "org.scalamock"                %% "scalamock"                  % "5.2.0"         % "test",
-    "org.jsoup"                    %  "jsoup"                      % "1.15.3"        % "test",
+    "org.jsoup"                    %  "jsoup"                      % "1.16.1"        % "test",
     "com.typesafe.play"            %% "play-test"                  % current         % "test",
     "org.scalatestplus.play"       %% "scalatestplus-play"         % "5.1.0"         % "test",
     "org.pegdown"                  %  "pegdown"                    % "1.6.0"         % "test, it",
     "com.github.tomakehurst"       %  "wiremock-jre8"              % "2.35.0"        % "test, it",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"       % "2.14.1"        % "test, it",
-    "uk.gov.hmrc"                  %% "bootstrap-test-play-28"     % "5.25.0"        % "test, it"
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"       % "2.15.2"        % "test, it",
+    "uk.gov.hmrc"                  %% "bootstrap-test-play-28"     % "7.18.0"        % "test, it"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")

--- a/test/base/BaseSpec.scala
+++ b/test/base/BaseSpec.scala
@@ -19,8 +19,14 @@ package base
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.libs.json._
 import play.api.i18n.Lang
+import play.api.inject.Injector
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.concurrent.ExecutionContext
 
 trait EnglishLanguage {
   implicit val lang: Lang = Lang("en")
@@ -102,7 +108,14 @@ trait TestConstants {
     }
 }
 
-trait BaseSpec extends AnyWordSpecLike with Matchers with ScalaFutures with TestConstants {
+trait BaseSpec extends AnyWordSpecLike with Matchers with ScalaFutures with TestConstants with GuiceOneAppPerSuite {
+
+  override lazy val app: Application = new GuiceApplicationBuilder()
+    .configure("metrics.enabled" -> "false")
+    .build()
+
+  val injector: Injector = app.injector
+  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
 
   def missingJsObjectAttrTests[T](jsObject: JsObject, attrsToIgnore: List[String] = Nil)(implicit objectReads: Reads[T]): Unit =
     jsObject.keys.filterNot(attrsToIgnore.contains(_)).foreach { attributeName =>

--- a/test/connectors/GuidanceConnectorSpec.scala
+++ b/test/connectors/GuidanceConnectorSpec.scala
@@ -17,14 +17,14 @@
 package connectors
 
 import base.BaseSpec
-import uk.gov.hmrc.http.HeaderCarrier
-import mocks.{MockAppConfig, MockHttpClient}
-import scala.concurrent.ExecutionContext.Implicits.global
-import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
-import play.api.libs.json.Json
-import core.models.ocelot.Process
-import scala.concurrent.Future
 import core.models.RequestOutcome
+import core.models.ocelot.Process
+import mocks.{MockAppConfig, MockHttpClient}
+import play.api.libs.json.Json
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
 
 class GuidanceConnectorSpec extends BaseSpec with MockHttpClient {
 

--- a/test/controllers/GuidanceControllerSpec.scala
+++ b/test/controllers/GuidanceControllerSpec.scala
@@ -16,48 +16,40 @@
 
 package controllers
 
-import java.time.Instant
 import akka.stream.Materializer
 import base.{BaseSpec, ViewFns}
 import config.ErrorHandler
-import play.api.i18n.{Messages, MessagesApi}
-import mocks.{MockAppConfig, MockGuidanceConnector, MockGuidanceService, MockSessionRepository}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.http.Status
-import play.api.mvc._
-import play.api.mvc.{AnyContentAsEmpty, BodyParsers}
-import play.api.test.FakeRequest
-import play.api.test.Helpers._
-import play.api.test.Helpers.stubMessagesControllerComponents
-import uk.gov.hmrc.http.SessionKeys
-import models.{PageContext, PageDesc, PageNext, GuidanceSession, PageEvaluationContext}
-import models.errors._
-import core.models.ocelot.errors._
-import core.models.ocelot.{KeyedStanza, Labels, Page, Phrase, Process, Meta, ProcessJson, Published, Scratch}
-import core.models.ocelot.stanzas.{CurrencyInput, DateInput, Question, Instruction, Sequence, PageStanza, VisualStanza, DataInput}
-import models.ui._
-import models.ui
-import play.api.test.CSRFTokenHelper._
-import play.api.data.FormError
-import core.models.errors._
-import core.models.ocelot.LabelCache
-import core.services._
-import repositories.{Session, SessionFSM, SessionKey, PageHistory}
-import scala.concurrent.{ExecutionContext, Future}
 import controllers.actions.SessionIdAction
-import play.api.inject.Injector
-import views.html._
-import services._
-import mocks.MockPageRenderer
-import uk.gov.hmrc.http.{RequestId, HeaderCarrier, HeaderNames}
+import core.models.errors._
+import core.models.ocelot.errors._
+import core.models.ocelot.stanzas.{CurrencyInput, DateInput, Question, Sequence, _}
+import core.models.ocelot.{KeyedStanza, LabelCache, Labels, Meta, Page, Phrase, Process, ProcessJson, Published, Scratch}
+import core.services._
 import forms.FormProviderFactory
 import forms.providers._
+import mocks._
+import models.errors._
+import models.ui._
+import models._
+import play.api.data.FormError
+import play.api.http.Status
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.mvc._
+import play.api.test.CSRFTokenHelper._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.{PageHistory, Session, SessionFSM, SessionKey}
+import services._
+import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames, RequestId, SessionKeys}
+import views.html._
 
-class GuidanceControllerSpec extends BaseSpec with ViewFns with GuiceOneAppPerSuite {
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
+
+class GuidanceControllerSpec extends BaseSpec with ViewFns {
 
   trait TestBase {
 
-    def injector: Injector = app.injector
     val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
     implicit val messages: Messages = messagesApi.preferred(Seq())
 

--- a/test/controllers/SessionBlockedControllerSpec.scala
+++ b/test/controllers/SessionBlockedControllerSpec.scala
@@ -17,18 +17,17 @@
 package controllers
 
 import base.BaseSpec
+import config.ErrorHandler
 import mocks.MockAppConfig
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
+import play.api.mvc.{AnyContentAsEmpty, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import config.ErrorHandler
 import views.html.session_blocked
-import play.api.test.Helpers.stubMessagesControllerComponents
-import play.api.mvc.{AnyContentAsEmpty, Result}
+
 import scala.concurrent.Future
 
-class SessionBlockedControllerSpec extends BaseSpec with GuiceOneAppPerSuite {
+class SessionBlockedControllerSpec extends BaseSpec {
 
   private trait Test {
 

--- a/test/controllers/SessionTimeoutPageControllerSpec.scala
+++ b/test/controllers/SessionTimeoutPageControllerSpec.scala
@@ -16,25 +16,23 @@
 
 package controllers
 
-import java.time.Instant
-
 import base.BaseSpec
-import mocks.{MockAppConfig, MockGuidanceService}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.http.Status
-import play.api.test.FakeRequest
-import play.api.test.Helpers._
 import config.ErrorHandler
 import core.models.errors._
 import core.models.ocelot.{Process, ProcessJson, Published}
+import mocks.{MockAppConfig, MockGuidanceService}
 import models.GuidanceSession
-import views.html.{user_deleted_session, system_timedout_session}
-import play.api.test.Helpers.stubMessagesControllerComponents
-import uk.gov.hmrc.http.SessionKeys
+import play.api.http.Status
 import play.api.mvc.{AnyContentAsEmpty, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.SessionKeys
+import views.html.{system_timedout_session, user_deleted_session}
+
+import java.time.Instant
 import scala.concurrent.Future
 
-class SessionTimeoutPageControllerSpec extends BaseSpec with GuiceOneAppPerSuite {
+class SessionTimeoutPageControllerSpec extends BaseSpec {
 
   private trait Test extends MockGuidanceService with ProcessJson {
 

--- a/test/controllers/SwitchLanguageControllerSpec.scala
+++ b/test/controllers/SwitchLanguageControllerSpec.scala
@@ -16,21 +16,17 @@
 
 package controllers
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.http.Status
+import base.BaseSpec
+import mocks.MockAppConfig
+import play.api._
+import play.api.http.{HeaderNames, Status}
+import play.api.i18n.{DefaultLangsProvider, MessagesApi}
+import play.api.mvc.Cookies
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.api._
-import play.api.mvc.Cookies
-import play.api.i18n.{MessagesApi, DefaultLangsProvider}
-import play.api.test.Helpers.stubMessagesControllerComponents
 import uk.gov.hmrc.play.language.LanguageUtils
-import play.api.http.HeaderNames
-import mocks.MockAppConfig
 
-class SwitchLanguageControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+class SwitchLanguageControllerSpec extends BaseSpec {
   private val fakeRequest = FakeRequest("GET", "/")
   private val env = Environment.simple()
   private val configuration = Configuration.load(env)

--- a/test/models/GuidanceSessionSpec.scala
+++ b/test/models/GuidanceSessionSpec.scala
@@ -16,16 +16,14 @@
 
 package models
 
-import core.models.ocelot._
 import base.BaseSpec
-import play.api.i18n.MessagesApi
-import play.api.inject.Injector
+import core.models.ocelot._
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.MessagesApi
 import services.SecuredProcessBuilder
 
 class GuidanceSessionSpec extends BaseSpec with GuiceOneAppPerSuite {
 
-  def injector: Injector = app.injector
   val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   val securedProcessBuilder = new SecuredProcessBuilder(messagesApi)
 

--- a/test/models/ocelot/stanzas/GroupRenderingSpec.scala
+++ b/test/models/ocelot/stanzas/GroupRenderingSpec.scala
@@ -16,17 +16,14 @@
 
 package models.ocelot.stanzas
 
-import base.{WelshLanguage, BaseSpec, EnglishLanguage}
+import base.{BaseSpec, EnglishLanguage, WelshLanguage}
 import core.models.ocelot._
 import core.models.ocelot.stanzas._
-import services._
-import play.api.inject.Injector
 import play.api.i18n.{Messages, MessagesApi}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import services._
 
-class GroupRenderingSpec extends BaseSpec with GuiceOneAppPerSuite {
+class GroupRenderingSpec extends BaseSpec {
 
-  private def injector: Injector = app.injector
   val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
 
   trait EnglishTest extends EnglishLanguage{

--- a/test/models/ui/OutputFormatSpec.scala
+++ b/test/models/ui/OutputFormatSpec.scala
@@ -16,17 +16,12 @@
 
 package models.ui
 
-import play.api.inject.Injector
-import play.api.i18n.{Lang, Messages, MessagesApi}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-
 import base.BaseSpec
+import play.api.i18n.{Lang, Messages, MessagesApi}
 
-class OutputFormatSpec extends BaseSpec with GuiceOneAppPerSuite {
+class OutputFormatSpec extends BaseSpec {
 
   trait Test {
-
-    private def injector: Injector = app.injector
 
     val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
   }

--- a/test/services/EnglishTextBuilderSpec.scala
+++ b/test/services/EnglishTextBuilderSpec.scala
@@ -16,20 +16,17 @@
 
 package services
 
-import play.api.inject.Injector
-import play.api.i18n.{Messages, MessagesApi}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import base.{EnglishLanguage, BaseSpec}
+import base.{BaseSpec, EnglishLanguage}
 import core.models.ocelot._
 import models.PageDesc
 import models.ui.{Link, Text, Words}
+import play.api.i18n.{Messages, MessagesApi}
 
 
-class EnglishTextBuilderSpec extends BaseSpec with GuiceOneAppPerSuite {
+class EnglishTextBuilderSpec extends BaseSpec {
 
   trait Test extends ProcessJson with EnglishLanguage {
 
-    private def injector: Injector = app.injector
     val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
     implicit val messages: Messages = messagesApi.preferred(Seq())
 

--- a/test/services/EnglishUIBuilderSpec.scala
+++ b/test/services/EnglishUIBuilderSpec.scala
@@ -16,25 +16,20 @@
 
 package services
 
-import play.api.inject.Injector
-import play.api.i18n.{Messages, MessagesApi}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import core.services._
 import base.{BaseSpec, EnglishLanguage}
 import core.models.ocelot._
-import core.models.ocelot.stanzas._
 import core.models.ocelot.errors.UnsupportedUiPatternError
+import core.models.ocelot.stanzas._
+import core.services._
 import models.ocelot.stanzas._
-import models.PageDesc
-import models.ui
-import models.ui.{BulletPointList, ConfirmationPanel, CyaSummaryList, Details, ErrorMsg, FormPage, H1, H3, H4, Sequence}
-import models.ui.{InsetText, Link, Paragraph, RequiredErrorMsg, Table, Text, WarningText, Words}
+import models.{PageDesc, ui}
+import models.ui.{BulletPointList, ConfirmationPanel, CyaSummaryList, Details, ErrorMsg, FormPage, H1, H3, H4, InsetText, Link, Paragraph, RequiredErrorMsg, Sequence, Table, Text, WarningText, Words}
+import play.api.i18n.{Messages, MessagesApi}
 
-class EnglishUIBuilderSpec extends BaseSpec with ProcessJson with EnglishLanguage with GuiceOneAppPerSuite {
+class EnglishUIBuilderSpec extends BaseSpec with ProcessJson with EnglishLanguage {
   implicit val labels: Labels = LabelCache()
 
   trait BaseTest {
-    private def injector: Injector = app.injector
     val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
     implicit val messages: Messages = messagesApi.preferred(Seq())
   }

--- a/test/services/GuidanceServiceSpec.scala
+++ b/test/services/GuidanceServiceSpec.scala
@@ -17,30 +17,22 @@
 package services
 
 import base.BaseSpec
-
-import core.models.errors._
-import core.models.ocelot.errors._
-import models.errors._
-import core.models.ocelot.Scratch
-import mocks.{MockAppConfig, MockGuidanceConnector, MockPageBuilder, MockPageRenderer, MockSessionRepository, MockUIBuilder}
 import core.models.errors.{DatabaseError, NotFoundError}
-import core.models.ocelot.stanzas.{EndStanza, Instruction, Question, PageStanza, VisualStanza, DataInput}
-import core.models.ocelot.{Page, KeyedStanza, Process, SecuredProcess, ProcessJson, LabelCache, Labels, Phrase, Published}
-import models.ui
-import models.{PageDesc, PageNext, PageEvaluationContext}
-import uk.gov.hmrc.http.{RequestId, HeaderCarrier}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import models.{GuidanceSession, PageContext}
-import play.api.i18n.{Messages, MessagesApi, Lang}
-import play.api.inject.Injector
-import repositories.{Session, SessionFSM, SessionKey, PageHistory}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import core.models.ocelot.errors._
+import core.models.ocelot.stanzas._
+import core.models.ocelot.{KeyedStanza, LabelCache, Labels, Page, Phrase, Process, ProcessJson, Published, Scratch, SecuredProcess}
+import mocks._
+import models._
+import models.errors._
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import repositories.{PageHistory, Session, SessionFSM, SessionKey}
+import uk.gov.hmrc.http.{HeaderCarrier, RequestId}
+
 import java.time.Instant
+import scala.concurrent.Future
 
-class GuidanceServiceSpec extends BaseSpec  with GuiceOneAppPerSuite {
+class GuidanceServiceSpec extends BaseSpec {
 
-  def injector: Injector = app.injector
   val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   implicit val messages: Messages = messagesApi.preferred(Seq())
   val rId: String = "71dcc4a3-9d19-47f5-ad97-74bb6c2a15c4"

--- a/test/services/PageRendererSpec.scala
+++ b/test/services/PageRendererSpec.scala
@@ -16,25 +16,21 @@
 
 package services
 
-import core.services._
 import base.BaseSpec
+import core.models.ocelot._
 import core.models.ocelot.errors._
 import core.models.ocelot.stanzas._
-import core.models.ocelot._
-import models.errors._
-import play.api.libs.json._
-import play.api.i18n.{Messages, MessagesApi, Lang}
+import core.services._
 import mocks.MockAppConfig
-import play.api.inject.Injector
-import play.api.i18n.MessagesApi
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import models.errors._
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import play.api.libs.json._
 
-class PageRendererSpec extends BaseSpec with ProcessJson with GuiceOneAppPerSuite {
+class PageRendererSpec extends BaseSpec with ProcessJson {
 
   // Define instance of class used in testing
   val pageBuilder = new PageBuilder(new Timescales(new DefaultTodayProvider))
   val renderer: PageRenderer = new PageRenderer(MockAppConfig)
-  private def injector: Injector = app.injector
   val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
   implicit val messages: Messages = messagesApi.preferred(Seq())
   val meta: Meta = Json.parse(prototypeMetaSection).as[Meta]

--- a/test/services/RetrieveAndCacheServiceSpec.scala
+++ b/test/services/RetrieveAndCacheServiceSpec.scala
@@ -17,23 +17,18 @@
 package services
 
 import base.BaseSpec
-
-import mocks.{MockGuidanceConnector, MockPageBuilder, MockSessionRepository}
-import core.models.ocelot.stanzas._
-import core.models.ocelot.{Page, KeyedStanza, Process, ProcessJson, Scratch, Published, Approval, PageReview}
-import models.ui
-import models.PageNext
-import uk.gov.hmrc.http.HeaderCarrier
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import play.api.i18n.MessagesApi
-import play.api.inject.Injector
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import core.models.errors.NotFoundError
+import core.models.ocelot.stanzas._
+import core.models.ocelot.{Approval, KeyedStanza, Page, PageReview, Process, ProcessJson, Published, Scratch}
+import mocks.{MockGuidanceConnector, MockPageBuilder, MockSessionRepository}
+import models.{PageNext, ui}
+import play.api.i18n.MessagesApi
+import uk.gov.hmrc.http.HeaderCarrier
 
-class RetrieveAndCacheServiceSpec extends BaseSpec  with GuiceOneAppPerSuite {
+import scala.concurrent.Future
 
-  def injector: Injector = app.injector
+class RetrieveAndCacheServiceSpec extends BaseSpec {
+
   val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
   trait Test extends MockGuidanceConnector with MockSessionRepository with MockPageBuilder with ProcessJson {

--- a/test/services/SecuredProcessBuilderSpec.scala
+++ b/test/services/SecuredProcessBuilderSpec.scala
@@ -16,18 +16,14 @@
 
 package services
 
-import core.services.{Timescales, DefaultTodayProvider, PageBuilder}
 import base.BaseSpec
-
 import core.models.ocelot._
 import core.models.ocelot.stanzas.Stanza
-import play.api.libs.json._
+import core.services.{DefaultTodayProvider, PageBuilder, Timescales}
 import play.api.i18n.MessagesApi
-import play.api.inject.Injector
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.libs.json._
 
-class SecuredProcessBuilderSpec extends BaseSpec with ProcessJson with GuiceOneAppPerSuite {
-  def injector: Injector = app.injector
+class SecuredProcessBuilderSpec extends BaseSpec with ProcessJson {
   val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
   val meta: Meta = Json.parse(prototypeMetaSection).as[Meta]

--- a/test/services/SequencePageRenderSpec.scala
+++ b/test/services/SequencePageRenderSpec.scala
@@ -16,20 +16,17 @@
 
 package services
 
-import core.services._
 import base.BaseSpec
 import core.models.ocelot._
+import core.services._
 import mocks.MockAppConfig
-import play.api.inject.Injector
 import play.api.i18n.{Messages, MessagesApi}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
-class SequencePageRenderSpec extends BaseSpec with ProcessJson with GuiceOneAppPerSuite {
+class SequencePageRenderSpec extends BaseSpec with ProcessJson {
 
   // Define instance of class used in testing
   val pageBuilder = new PageBuilder(new Timescales(new DefaultTodayProvider))
   val renderer: PageRenderer = new PageRenderer(MockAppConfig)
-  private def injector: Injector = app.injector
   val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
   implicit val messages: Messages = messagesApi.preferred(Seq())
   implicit val ctx: UIContext = UIContext(LabelCache(), Map(), messages)

--- a/test/services/TextBuilderSpec.scala
+++ b/test/services/TextBuilderSpec.scala
@@ -17,17 +17,14 @@
 package services
 
 import base.BaseSpec
-import play.api.inject.Injector
-import play.api.i18n.{Messages, MessagesApi}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import core.models.ocelot._
+import play.api.i18n.{Messages, MessagesApi}
 
-class TextBuilderSpec extends BaseSpec with GuiceOneAppPerSuite {
+class TextBuilderSpec extends BaseSpec {
 
   import TextBuilder._
 
   trait Test {
-    private def injector: Injector = app.injector
     val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
     implicit val messages: Messages = messagesApi.preferred(Seq())
 

--- a/test/services/WelshTextBuilderSpec.scala
+++ b/test/services/WelshTextBuilderSpec.scala
@@ -16,20 +16,16 @@
 
 package services
 
-import play.api.inject.Injector
-import play.api.i18n.{Messages, MessagesApi}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import base.{WelshLanguage, BaseSpec}
-
+import base.{BaseSpec, WelshLanguage}
 import core.models.ocelot._
 import models.PageDesc
 import models.ui.{Link, Text, Words}
+import play.api.i18n.{Messages, MessagesApi}
 
-class WelshTextBuilderSpec extends BaseSpec with WelshLanguage with GuiceOneAppPerSuite {
+class WelshTextBuilderSpec extends BaseSpec with WelshLanguage {
 
   trait Test extends ProcessJson {
 
-    private def injector: Injector = app.injector
     val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
     implicit val messages: Messages = messagesApi.preferred(Seq(TextBuilder.Welsh))
 

--- a/test/services/WelshUIBuilderSpec.scala
+++ b/test/services/WelshUIBuilderSpec.scala
@@ -16,25 +16,20 @@
 
 package services
 
-import play.api.inject.Injector
-import play.api.i18n.{Messages, MessagesApi}
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import core.services._
 import base.{BaseSpec, WelshLanguage}
 import core.models.ocelot._
-import core.models.ocelot.stanzas._
 import core.models.ocelot.errors.UnsupportedUiPatternError
+import core.models.ocelot.stanzas._
+import core.services._
 import models.ocelot.stanzas._
-import models.PageDesc
-import models.ui
-import models.ui.{BulletPointList, ConfirmationPanel, CyaSummaryList, Details, ErrorMsg, FormPage, H1, H3, H4, Sequence => Sequence}
-import models.ui.{InsetText, Link, Paragraph, RequiredErrorMsg, Table, Text, WarningText, Words}
+import models.ui.{BulletPointList, ConfirmationPanel, CyaSummaryList, Details, ErrorMsg, FormPage, H1, H3, H4, InsetText, Link, Paragraph, RequiredErrorMsg, Sequence, Table, Text, WarningText, Words}
+import models.{PageDesc, ui}
+import play.api.i18n.{Messages, MessagesApi}
 
-class WelshUIBuilderSpec extends BaseSpec with ProcessJson with WelshLanguage with GuiceOneAppPerSuite {
+class WelshUIBuilderSpec extends BaseSpec with ProcessJson with WelshLanguage {
   implicit val labels: Labels = LabelCache()
 
   trait BaseTest {
-    private def injector: Injector = app.injector
     val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
     implicit val messages: Messages = messagesApi.preferred(Seq(TextBuilder.Welsh))
   }

--- a/test/views/admin/RenderStanzaSpec.scala
+++ b/test/views/admin/RenderStanzaSpec.scala
@@ -29,11 +29,10 @@ import views.html.admin.render_stanza
 
 import scala.collection.JavaConverters._
 
-class RenderStanzaSpec extends BaseSpec with ViewSpec with ViewFns with GuiceOneAppPerSuite {
+class RenderStanzaSpec extends BaseSpec with ViewSpec with ViewFns {
 
   private trait Test {
     implicit val labels: Labels = LabelCache()
-    private def injector: Injector = app.injector
     def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
 
     implicit val request = FakeRequest("GET", "/")

--- a/test/views/admin/StanzaTableSpec.scala
+++ b/test/views/admin/StanzaTableSpec.scala
@@ -30,10 +30,9 @@ import views.html.admin.stanza_table
 
 import scala.collection.JavaConverters._
 
-class StanzaTableSpec extends BaseSpec with ViewSpec with ViewFns with GuiceOneAppPerSuite {
+class StanzaTableSpec extends BaseSpec with ViewSpec with ViewFns {
 
   private trait Test {
-    private def injector: Injector = app.injector
     def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
     val stable = injector.instanceOf[stanza_table]
     implicit val request = FakeRequest("GET", "/")

--- a/test/views/components/ConfirmationPanelSpec.scala
+++ b/test/views/components/ConfirmationPanelSpec.scala
@@ -34,8 +34,6 @@ class ConfirmationPanelSpec extends BaseSpec with ViewFns with GuiceOneAppPerSui
 
   private trait Test {
 
-    private def injector: Injector = app.injector
-
     def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
 
     val fakeRequest = FakeRequest("GET", "/confirmation")

--- a/test/views/components/DetailsSpec.scala
+++ b/test/views/components/DetailsSpec.scala
@@ -31,11 +31,9 @@ import play.api.test.FakeRequest
 import views.html.components.details
 import scala.collection.JavaConverters._
 
-class DetailsSpec extends BaseSpec with ViewFns with ViewSpec with GuiceOneAppPerSuite {
+class DetailsSpec extends BaseSpec with ViewFns with ViewSpec {
 
   private trait Test {
-
-    private def injector: Injector = app.injector
 
     def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
     implicit val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/confirmation")

--- a/test/views/components/SessionTimeoutSpec.scala
+++ b/test/views/components/SessionTimeoutSpec.scala
@@ -26,11 +26,9 @@ import play.api.inject.Injector
 import play.api.test.FakeRequest
 import views.html.{user_deleted_session, system_timedout_session}
 
-class SessionTimeoutSpec extends BaseSpec with ViewFns with ViewSpec with GuiceOneAppPerSuite {
+class SessionTimeoutSpec extends BaseSpec with ViewFns with ViewSpec {
 
   trait Test {
-
-    private def injector: Injector = app.injector
 
     def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
 


### PR DESCRIPTION
- Added answerStorageId to ensure answers are stored using the flow label as well as the url.
- Explicitly disables sessionIdFilter, this was previously the default but with bootstrap v7.4.0 enabled became the default
- Left hmrc mongo on 0.73 as upgrading requires reworking of the LocalDateTime formatter