### PR TITLE
DL-14054: Switch to using rawPagehistory, pageHistory optional in Session

### DIFF
--- a/app/core/models/errors/Error.scala
+++ b/app/core/models/errors/Error.scala
@@ -43,6 +43,7 @@ object IllegalPageSubmissionError extends Error("ILLEGAL_PAGE_SUBMISSION")
 object SessionNotFoundError extends Error("SESSION_NOT_FOUND")
 object TransactionFaultError extends Error("TRANSACTION_FAULT")
 object PageHistoryError extends Error("PAGE_HISTORY_FAULT")
+object RawPageHistoryError extends Error("RAW_PAGE_HISTORY_FAULT")
 object CachedProcessNotFoundError extends Error("CACHED_PROCESS_NOT_FOUND")
 
 object Error {

--- a/app/models/GuidanceSession.scala
+++ b/app/models/GuidanceSession.scala
@@ -50,7 +50,7 @@ case class GuidanceSession(process: Process,
 }
 
 object GuidanceSession {
-  def apply(sp: Session, process: Process, pageMap: Map[String, PageNext]): GuidanceSession =
+  def apply(sp: Session, process: Process, pageMap: Map[String, PageNext], pageHistory: List[PageHistory]): GuidanceSession =
     GuidanceSession(process,
                     sp.answers,
                     sp.labels,
@@ -58,10 +58,10 @@ object GuidanceSession {
                     sp.continuationPool,
                     pageMap,
                     sp.legalPageIds,
-                    sp.pageHistory.reverse.headOption.map(_.url.drop(process.meta.processCode.length)),
+                    pageHistory.reverse.headOption.map(_.url.drop(process.meta.processCode.length)),
                     None,
                     sp.runMode.getOrElse(Published),
-                    sp.pageHistory)
+                    pageHistory)
 }
 
 case class PageNext(id: String, next: List[String] = Nil, linked: List[String] = Nil, title: Option[String] = None, url: Option[String] = None)

--- a/app/models/Session.scala
+++ b/app/models/Session.scala
@@ -36,8 +36,7 @@ final case class Session(
    flowStack: List[FlowStage],
    continuationPool: Map[String, Stanza],
    answers: Map[String, String],
-   pageHistory: List[PageHistory],
-   rawPageHistory: Option[List[RawPageHistory]],
+   rawPageHistory: List[RawPageHistory],
    legalPageIds: List[String],
    requestId: Option[String],
    lastAccessed: Instant, // expiry time
@@ -55,7 +54,7 @@ object Session {
             lastAccessed: Instant = Instant.now,
             timescalesVersion : Option[Long],
             ratesVersion : Option[Long]): Session =
-    Session(key, Some(runMode), processId, Map(), Nil, Map(), Map(), Nil, None, legalPageIds, None, lastAccessed, processVersion, timescalesVersion, ratesVersion)
+    Session(key, Some(runMode), processId, Map(), Nil, Map(), Map(), Nil, legalPageIds, None, lastAccessed, processVersion, timescalesVersion, ratesVersion)
 
   implicit lazy val format: Format[Session] = Json.format[Session]
 }

--- a/test/controllers/GuidanceControllerSpec.scala
+++ b/test/controllers/GuidanceControllerSpec.scala
@@ -416,7 +416,7 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
     "return a NOT_FOUND response" in new QuestionSubmissionTest {
       val url = "/rent/less-than-1000/do-you-receive-any-income"
       val session = Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(), Nil, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion)
-      val guidanceSession = GuidanceSession(session, process, Map(), List(PageHistory(s"tell-hmrc/$url", Nil)))
+      val guidanceSession = GuidanceSession(session, process, Map(), List(PageHistory(s"tell-hmrc$url", Nil)))
 
       MockSessionService
         .get(processId, process.meta.processCode, requestId)
@@ -454,14 +454,14 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
         .get(processId, process.meta.processCode, requestId)
         .returns(Future.successful(Right(
           GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(),
-            List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(url -> PageNext("36", Nil, Nil), outOfSequence -> PageNext("80", Nil, Nil)), List(PageHistory(s"$processCode/start", Nil)))
+            List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(url -> PageNext("36", Nil, Nil), outOfSequence -> PageNext("80", Nil, Nil)), List(PageHistory(s"tell-hmrc$url", Nil)))
         )))
 
       MockSessionService
         .getNoUpdate(processId, process.meta.processCode)
         .returns(Future.successful(Right(
           GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id,Map(), Nil, Map(), Map(),
-                  List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(url -> PageNext("36", Nil, Nil), outOfSequence -> PageNext("80", Nil, Nil)), List(PageHistory(s"$processCode/start", Nil)))
+                  List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(url -> PageNext("36", Nil, Nil), outOfSequence -> PageNext("80", Nil, Nil)), List(PageHistory(s"tell-hmrc$url", Nil)))
         )))
 
       override val fakeRequest = FakeRequest("POST", outOfSequence)
@@ -1564,7 +1564,7 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
 
       val process = prototypeJson.as[Process]
       val session = GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(),
-        List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(), List())
+        List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(), List(PageHistory(s"${process.meta.processCode}$path",Nil)))
 
       MockSessionService
         .get(sessionId, process.meta.processCode, requestId)

--- a/test/controllers/GuidanceControllerSpec.scala
+++ b/test/controllers/GuidanceControllerSpec.scala
@@ -415,8 +415,8 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
 
     "return a NOT_FOUND response" in new QuestionSubmissionTest {
       val url = "/rent/less-than-1000/do-you-receive-any-income"
-      val session = Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(), List(PageHistory(s"tell-hmrc$url",Nil)), None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion)
-      val guidanceSession = GuidanceSession(session, process, Map())
+      val session = Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(), Nil, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion)
+      val guidanceSession = GuidanceSession(session, process, Map(), List(PageHistory(s"tell-hmrc/$url", Nil)))
 
       MockSessionService
         .get(processId, process.meta.processCode, requestId)
@@ -454,14 +454,14 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
         .get(processId, process.meta.processCode, requestId)
         .returns(Future.successful(Right(
           GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(),
-                  List(PageHistory(s"tell-hmrc$url",Nil)), None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(url -> PageNext("36", Nil, Nil), outOfSequence -> PageNext("80", Nil, Nil)))
+            List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(url -> PageNext("36", Nil, Nil), outOfSequence -> PageNext("80", Nil, Nil)), List(PageHistory(s"$processCode/start", Nil)))
         )))
 
       MockSessionService
         .getNoUpdate(processId, process.meta.processCode)
         .returns(Future.successful(Right(
           GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id,Map(), Nil, Map(), Map(),
-                  List(PageHistory(s"tell-hmrc$url",Nil)), None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(url -> PageNext("36", Nil, Nil), outOfSequence -> PageNext("80", Nil, Nil)))
+                  List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(url -> PageNext("36", Nil, Nil), outOfSequence -> PageNext("80", Nil, Nil)), List(PageHistory(s"$processCode/start", Nil)))
         )))
 
       override val fakeRequest = FakeRequest("POST", outOfSequence)
@@ -484,14 +484,14 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
         .get(processId, process.meta.processCode, requestId)
         .returns(Future.successful(Right(
           GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(),
-                  List(), None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map())
+                  List(), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(), List())
         )))
 
       MockSessionService
         .getNoUpdate(processId, process.meta.processCode)
         .returns(Future.successful(Right(
           GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(),
-                  List(), None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map())
+                  List(), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(), List())
         )))
 
       override val fakeRequest = FakeRequest("POST", "some-other-url")
@@ -507,7 +507,7 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
     "Sync process when process code doesnt match current session" in new QuestionSubmissionTest with MockGuidanceService {
       val session = Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id,Map(), Nil, Map(),
                             Map(),
-                            List(PageHistory(s"tell-hmrc$url",Nil)), None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion)
+                            List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion)
 
       val guidanceSession = GuidanceSession(process, Map(), Map(), Nil, Map(), Map(), Nil, Some("/current-page-url"), None, Published, Nil)
       MockGuidanceService
@@ -520,7 +520,7 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
 
       MockSessionService
         .getNoUpdate(processId, process.meta.processCode)
-        .returns(Future.successful(Right(GuidanceSession(session, process, Map(url -> PageNext("36", Nil, Nil))))))
+        .returns(Future.successful(Right(GuidanceSession(session, process, Map(url -> PageNext("36", Nil, Nil)), List()))))
 
       override val fakeRequest = FakeRequest("POST", path)
                                   .withSession(SessionKeys.sessionId -> processId)
@@ -1564,7 +1564,7 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
 
       val process = prototypeJson.as[Process]
       val session = GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(),
-                  List(PageHistory(s"${process.meta.processCode}$path", Nil)), None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map())
+        List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(), List())
 
       MockSessionService
         .get(sessionId, process.meta.processCode, requestId)
@@ -1594,7 +1594,7 @@ class GuidanceControllerSpec extends BaseSpec with ViewFns {
         .getNoUpdate(sessionId, processCode)
         .returns(Future.successful(Right(
           GuidanceSession(Session(SessionKey(processId, process.meta.processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(),
-                  List(), None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map())
+                  List(), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion), process, Map(), List())
         )))
 
       val result = target.getPage(processCode, path.drop(1), None)(fakeRequest)

--- a/test/repositories/SessionFSMSpec.scala
+++ b/test/repositories/SessionFSMSpec.scala
@@ -17,9 +17,10 @@
 package repositories
 
 import base.BaseSpec
-import core.models.ocelot.stanzas.{ValueStanza, Value, ScalarType}
-import models.{PageHistory, Session, SessionKey}
-import core.models.ocelot.{Process, ProcessJson, SequenceJson, FlowStage, ScalarLabel, ListLabel, Flow, Continuation, Label, LabelValue, Phrase, Published}
+import core.models.ocelot.stanzas.{ScalarType, Value, ValueStanza}
+import models.{SessionKey, PageHistory, Session, RawPageHistory}
+import core.models.ocelot.{SequenceJson, Published, LabelValue, Continuation, Phrase, ListLabel, FlowStage, Label, ScalarLabel, Flow, Process, ProcessJson}
+
 import java.time.Instant
 
 class SessionFSMSpec extends BaseSpec {
@@ -61,8 +62,7 @@ class SessionFSMSpec extends BaseSpec {
         Nil,
         Map(),
         Map(),
-        List(PageHistory("/start", Nil)),
-        None,
+        List(RawPageHistory("start", Nil)),
         Nil,
         None,
         Instant.now,
@@ -208,8 +208,7 @@ class SessionFSMSpec extends BaseSpec {
         List(Flow("8",Some(LabelValue("Choice",phraseThree))), Flow("88",Some(LabelValue("Choice",phraseFour))), Continuation("2")),
         Map("6" -> ValueStanza(List(Value(ScalarType,"SecondSeqChoice","Loop value = [label:Choice]")),Vector("end"),false)),
         Map("/start" -> "2,3"),
-        List(PageHistory("/start", Nil)),
-        None,
+        List(RawPageHistory("start", Nil)),
         Nil,
         None,
         Instant.now,

--- a/test/services/GuidanceServiceSpec.scala
+++ b/test/services/GuidanceServiceSpec.scala
@@ -148,10 +148,11 @@ class GuidanceServiceSpec extends BaseSpec {
           GuidanceSession(
             Session(
               SessionKey(sessionRepoId, processCode), 
-              Some(Published), process.meta.id, Map(), Nil, Map(), Map(), Nil, None, Nil, None, Instant.now, process.meta.lastUpdate,
+              Some(Published), process.meta.id, Map(), Nil, Map(), Map(), List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate,
               process.meta.timescalesVersion,
               process.meta.ratesVersion
-            ), process, Map(page.url -> PageNext("2", Nil))
+            ), process, Map(page.url -> PageNext("2", Nil)),
+            List(PageHistory(s"$processCode/start", Nil))
           )
         )))
 
@@ -187,11 +188,12 @@ class GuidanceServiceSpec extends BaseSpec {
           GuidanceSession(
             Session(
               SessionKey(sessionRepoId, processCode), 
-              Some(Published), process.meta.id, Map(), Nil, Map(), Map(), Nil, None, Nil, None, Instant.now, process.meta.lastUpdate,
+              Some(Published), process.meta.id, Map(), Nil, Map(), Map(), List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate,
               process.meta.timescalesVersion,
               process.meta.ratesVersion
             ), 
-            process, Map(page.url -> PageNext("2", Nil))
+            process, Map(page.url -> PageNext("2", Nil)),
+            List(PageHistory(s"$processCode/start", Nil))
           )
         )))
 
@@ -224,11 +226,12 @@ class GuidanceServiceSpec extends BaseSpec {
           GuidanceSession(
             Session(
               SessionKey(sessionRepoId, processCode), 
-              Some(Published), process.meta.id, Map(), Nil, Map(), Map(), Nil, None, Nil, None, Instant.now, process.meta.lastUpdate,
+              Some(Published), process.meta.id, Map(), Nil, Map(), Map(), List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate,
               process.meta.timescalesVersion,
               process.meta.ratesVersion
             ), 
-            process, Map(lastPageUrl -> PageNext("2", Nil))
+            process, Map(lastPageUrl -> PageNext("2", Nil)),
+            Nil
           )
         )))
 
@@ -275,11 +278,12 @@ class GuidanceServiceSpec extends BaseSpec {
           GuidanceSession(
             Session(
               SessionKey(sessionRepoId, processCode), 
-              Some(Published), process.meta.id, Map(), Nil, Map(), Map(), Nil, None, Nil, None, Instant.now, process.meta.lastUpdate,
+              Some(Published), process.meta.id, Map(), Nil, Map(), Map(), List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate,
               process.meta.timescalesVersion,
               process.meta.ratesVersion
             ), 
-            process, Map(lastPageUrl -> PageNext("2", Nil))
+            process, Map(lastPageUrl -> PageNext("2", Nil)),
+            Nil
           )
         )))
 
@@ -320,11 +324,12 @@ class GuidanceServiceSpec extends BaseSpec {
           GuidanceSession(
             Session(
               SessionKey(sessionRepoId, processCode), 
-              Some(Published), fullProcess.meta.id, Map(), Nil, Map(), Map(lastPageUrl -> "answer"), Nil, None, Nil, None, Instant.now, fullProcess.meta.lastUpdate,
+              Some(Published), fullProcess.meta.id, Map(), Nil, Map(), Map(lastPageUrl -> "answer"), List(RawPageHistory("start", Nil)), Nil, None, Instant.now, fullProcess.meta.lastUpdate,
               process.meta.timescalesVersion,
               process.meta.ratesVersion
             ), 
-            fullProcess, Map(lastPageUrl -> PageNext("2"))
+            fullProcess, Map(lastPageUrl -> PageNext("2")),
+            Nil
           )
         )))
 
@@ -373,11 +378,11 @@ class GuidanceServiceSpec extends BaseSpec {
           GuidanceSession(
             Session(
               SessionKey(sessionRepoId, processCode), 
-              Some(Published), fullProcess.meta.id, Map(), Nil, Map(), Map(), Nil, None, Nil, None, Instant.now, fullProcess.meta.lastUpdate,
+              Some(Published), fullProcess.meta.id, Map(), Nil, Map(), Map(), List(RawPageHistory("start", Nil)), Nil, None, Instant.now, fullProcess.meta.lastUpdate,
               process.meta.timescalesVersion,
               process.meta.ratesVersion
             ), 
-            fullProcess, Map()
+            fullProcess, Map(), List()
           )
         )))
 
@@ -396,8 +401,8 @@ class GuidanceServiceSpec extends BaseSpec {
   "Calling getCurrentGuidanceSession" should {
 
     "successfully retrieve a process context when the session data contains a single process" in new Test {
-      val expectedSession = Session(SessionKey(sessionRepoId, processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(), Nil, None, Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion)
-      val expectedGuidanceSession: GuidanceSession = GuidanceSession(expectedSession, process, Map())
+      val expectedSession = Session(SessionKey(sessionRepoId, processCode), Some(Published), process.meta.id, Map(), Nil, Map(), Map(), List(RawPageHistory("start", Nil)), Nil, None, Instant.now, process.meta.lastUpdate, process.meta.timescalesVersion, process.meta.ratesVersion)
+      val expectedGuidanceSession: GuidanceSession = GuidanceSession(expectedSession, process, Map(), List())
 
       MockSessionService
         .getNoUpdate(sessionRepoId, process.meta.processCode)
@@ -443,14 +448,14 @@ class GuidanceServiceSpec extends BaseSpec {
     "When passed a url to the passphrase page should send no pageHistory url to the repository" in new Test {
       val expectedSession: Session = Session(SessionKey(sessionRepoId, process.meta.processCode), 
                                              Some(Published), 
-                                             process.meta.id, Map(), Nil, Map(), Map(), Nil, None, Nil, None,
+                                             process.meta.id, Map(), Nil, Map(), Map(), List(RawPageHistory("start", Nil)), Nil, None,
                                              Instant.now, process.meta.lastUpdate,
                                              process.meta.timescalesVersion,
                                              process.meta.ratesVersion)
 
       MockSessionService
         .get(sessionRepoId, process.meta.processCode, requestId)
-        .returns(Future.successful(Right(GuidanceSession(expectedSession, process, Map()))))
+        .returns(Future.successful(Right(GuidanceSession(expectedSession, process, Map(), List()))))
 
       target.getPageEvaluationContext(process.meta.processCode, s"/${SecuredProcess.SecuredProcessStartUrl}", false, sessionRepoId)
     }
@@ -458,13 +463,13 @@ class GuidanceServiceSpec extends BaseSpec {
     "When passed a url to a standard page should send pageHistory url to the repository" in new Test {
     val expectedSession: Session = Session(SessionKey(sessionRepoId, process.meta.processCode), 
                                              Some(Published), 
-                                             process.meta.id, Map(), Nil, Map(), Map(), Nil, None, Nil, None,
+                                             process.meta.id, Map(), Nil, Map(), Map(), List(RawPageHistory("start", Nil)), Nil, None,
                                              Instant.now, process.meta.lastUpdate,
                                              process.meta.timescalesVersion,
                                              process.meta.ratesVersion)
       MockSessionService
         .get(sessionRepoId, process.meta.processCode, requestId)
-        .returns(Future.successful(Right(GuidanceSession(expectedSession, process, Map()))))
+        .returns(Future.successful(Right(GuidanceSession(expectedSession, process, Map(), List()))))
 
       target.getPageEvaluationContext(process.meta.processCode, s"/start", false, sessionRepoId)
     }

--- a/test/services/SessionServiceSpec.scala
+++ b/test/services/SessionServiceSpec.scala
@@ -54,7 +54,7 @@ class SessionServiceSpec extends BaseSpec with MockProcessCacheRepository with M
     val session = Session(
       SessionKey(processId, process.meta.processCode),
       Some(Published), process.meta.id,
-      Map(), Nil, Map(), Map(), Nil, None, Nil, None, Instant.now,
+      Map(), Nil, Map(), Map(), Nil, Nil, None, Instant.now,
       process.meta.lastUpdate,
       process.meta.timescalesVersion,
       process.meta.ratesVersion
@@ -265,7 +265,7 @@ class SessionServiceSpec extends BaseSpec with MockProcessCacheRepository with M
         .returns(Future.successful(Right(cachedProcess)))
 
       whenReady(target.guidanceSession(session)) {
-        case Right(gSession) if gSession == GuidanceSession(session, process, Map()) => succeed
+        case Right(gSession) if gSession == GuidanceSession(session, process, Map(), Nil) => succeed
         case _ => fail()
       }
     }


### PR DESCRIPTION
Switched to using rawPageHistory (now mandatory in the session model) and removed pageHistory from the session model, including changes to guidanceSession method and unit tests.