### PR TITLE
DL-15793: dependency and sbt ver update

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -19,17 +19,17 @@ import sbt.*
 object AppDependencies {
 
   val bootstrapVersion = "9.11.0"
-  val hmrcMongoVersion = "2.5.0"
+  val hmrcMongoVersion = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % hmrcMongoVersion,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "11.12.0"
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.0.0"
   )
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % hmrcMongoVersion,
-    "org.scalamock"     %% "scalamock"               % "6.2.0",
+    "org.scalamock"     %% "scalamock"               % "7.3.0",
     "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % bootstrapVersion
   ).map(_ % Test)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10


### PR DESCRIPTION
[info] Found 4 dependency updates for view-external-guidance-frontend
[info]   org.scalamock:scalamock:test                                           : 6.2.0              -> 7.3.0 
[info]   uk.gov.hmrc.mongo:hmrc-mongo-play-30                      : 2.5.0   -> 2.6.0            
[info]   uk.gov.hmrc.mongo:hmrc-mongo-test-play-30:test        : 2.5.0   -> 2.6.0            
[info]   uk.gov.hmrc:play-frontend-hmrc-play-30                        : 11.12.0 -> 11.13.0 -> 12.0.0
